### PR TITLE
Add Homebrew tap release automation

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -2,41 +2,59 @@ name: Python package
 
 on:
   schedule:
-    - cron:  '* 23 */2 * *' # At the end of every 2 days
+    - cron: "0 23 */2 * *"
   push:
     branches:
       - master
   pull_request:
     branches:
       - master
+  workflow_dispatch:
 
 jobs:
-  build:
-
+  offline-tests:
+    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 2
+      fail-fast: false
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: ["3.11", "3.13"]
 
     steps:
-    - uses: actions/checkout@v1
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install .
-    - name: Lint with flake8
-      run: |
-        pip install flake8
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: Test with pytest
-      run: |
-        pip install pytest
-        pytest
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+      - uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
+      - name: Check lockfile
+        run: uv lock --check
+      - name: Run offline tests
+        run: >
+          uv run --locked pytest -q
+          tests/test_cli.py
+          tests/test_providers.py
+          tests/test_download_manager.py
+          tests/test_chapter_archiver.py
+          tests/test_thread_safety.py
+          tests/test_fanfox_search.py
+          tests/test_fanfox_packed_js.py
+          tests/test_sort_key.py
+
+  live-provider-tests:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+      - uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
+      - name: Check lockfile
+        run: uv lock --check
+      - name: Run live provider tests
+        run: uv run --locked pytest -q tests/test_fanfox.py tests/test_mangadex.py

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,150 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "*.*.*"
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  release:
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+      - uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
+
+      - name: Validate release tag
+        id: meta
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF_NAME}"
+          if [[ ! "${version}" =~ ^[0-9]+[.][0-9]+[.][0-9]+$ ]]; then
+            echo "Release tags must use X.Y.Z format, got ${GITHUB_REF_NAME}" >&2
+            exit 1
+          fi
+          project_version="$(python -c 'import pathlib, tomllib; print(tomllib.loads(pathlib.Path("pyproject.toml").read_text())["project"]["version"])')"
+          if [[ "${version}" != "${project_version}" ]]; then
+            echo "Tag ${version} does not match pyproject.toml version ${project_version}" >&2
+            exit 1
+          fi
+          archive_url="https://github.com/alemar11/mangapy/archive/refs/tags/${version}.tar.gz"
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+          echo "archive_url=${archive_url}" >> "${GITHUB_OUTPUT}"
+
+      - name: Check lockfile
+        run: uv lock --check
+
+      - name: Run offline tests
+        run: >
+          uv run --locked pytest -q
+          tests/test_cli.py
+          tests/test_providers.py
+          tests/test_download_manager.py
+          tests/test_chapter_archiver.py
+          tests/test_thread_safety.py
+          tests/test_fanfox_search.py
+          tests/test_fanfox_packed_js.py
+          tests/test_sort_key.py
+
+      - name: Build distributions
+        run: uv build
+
+      - name: Publish to PyPI
+        run: uv publish --trusted-publishing automatic
+
+      - name: Compute source archive checksum
+        id: archive
+        run: |
+          set -euo pipefail
+          curl --fail --location --silent --show-error \
+            "${{ steps.meta.outputs.archive_url }}" \
+            --output mangapy-${{ steps.meta.outputs.version }}.tar.gz
+          sha256="$(shasum -a 256 mangapy-${{ steps.meta.outputs.version }}.tar.gz | awk '{print $1}')"
+          echo "sha256=${sha256}" >> "${GITHUB_OUTPUT}"
+
+      - name: Check out Homebrew tap
+        uses: actions/checkout@v6
+        with:
+          repository: alemar11/homebrew-tap
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: homebrew-tap
+
+      - name: Update Homebrew formula
+        working-directory: homebrew-tap
+        run: |
+          set -euo pipefail
+          mkdir -p Formula
+          cat > Formula/mangapy.rb <<'RUBY'
+          class Mangapy < Formula
+            include Language::Python::Virtualenv
+
+            desc "Manga downloader"
+            homepage "https://github.com/alemar11/mangapy"
+            url "__ARCHIVE_URL__"
+            sha256 "__ARCHIVE_SHA256__"
+            license "MIT"
+
+            depends_on "libyaml"
+            depends_on "pillow"
+            depends_on "python@3.13"
+
+            def install
+              virtualenv_install_with_resources using: "python@3.13"
+            end
+
+            test do
+              assert_match version.to_s, shell_output("#{bin}/mangapy --version")
+            end
+          end
+          RUBY
+          ruby -pi -e 'gsub("__ARCHIVE_URL__", ENV.fetch("ARCHIVE_URL")); gsub("__ARCHIVE_SHA256__", ENV.fetch("ARCHIVE_SHA256"))' Formula/mangapy.rb
+          for attempt in 1 2 3 4 5 6; do
+            if brew update-python-resources --exclude-packages pillow --package-name mangapy --version "${VERSION}" Formula/mangapy.rb; then
+              exit 0
+            fi
+            echo "PyPI resources not available yet; retrying (${attempt}/6)"
+            sleep 10
+          done
+          brew update-python-resources --exclude-packages pillow --package-name mangapy --version "${VERSION}" Formula/mangapy.rb
+        env:
+          ARCHIVE_URL: ${{ steps.meta.outputs.archive_url }}
+          ARCHIVE_SHA256: ${{ steps.archive.outputs.sha256 }}
+          VERSION: ${{ steps.meta.outputs.version }}
+
+      - name: Validate Homebrew formula
+        working-directory: homebrew-tap
+        run: |
+          set -euo pipefail
+          tap_root="$(brew --repository)/Library/Taps/alemar11"
+          mkdir -p "${tap_root}"
+          rm -rf "${tap_root}/homebrew-tap"
+          ln -s "${PWD}" "${tap_root}/homebrew-tap"
+          brew audit --strict --online mangapy
+          brew uninstall --force mangapy || true
+          brew install --build-from-source mangapy
+          brew test mangapy
+
+      - name: Commit Homebrew formula
+        working-directory: homebrew-tap
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Formula/mangapy.rb
+          if git diff --cached --quiet; then
+            echo "Homebrew formula is already up to date."
+            exit 0
+          fi
+          git commit -m "Update mangapy to ${{ steps.meta.outputs.version }}"
+          git push

--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ Manga downloader supporting the following sources:
 pipx install mangapy
 ```
 
+Or, on macOS with Homebrew:
+
+```
+brew install alemar11/tap/mangapy
+```
+
 ## Usage
 
 ### Terminal

--- a/docs/Distribution.md
+++ b/docs/Distribution.md
@@ -1,16 +1,50 @@
-## Generating distribution packages:
+## Distribution
 
-1. Build sdist and wheel with uv from the project root:
+`mangapy` is distributed through PyPI for `pipx` users and through the
+`alemar11/homebrew-tap` Homebrew tap for Brew users.
+
+## Release flow
+
+1. Bump the package version in `pyproject.toml`.
+2. Update and verify the lockfile:
+
+```
+uv lock
+uv lock --check
+```
+
+3. Run the offline preflight tests:
+
+```
+uv run --locked pytest -q \
+  tests/test_cli.py \
+  tests/test_providers.py \
+  tests/test_download_manager.py \
+  tests/test_chapter_archiver.py \
+  tests/test_thread_safety.py \
+  tests/test_fanfox_search.py \
+  tests/test_fanfox_packed_js.py \
+  tests/test_sort_key.py
+```
+
+4. Merge the release commit to `master`.
+5. Tag the release with the package version, without a `v` prefix:
+
+```
+git tag 3.0.2
+git push origin 3.0.2
+```
+
+The release workflow validates that the tag matches `pyproject.toml`, builds
+the package, publishes it to PyPI with Trusted Publishing, and updates
+`Formula/mangapy.rb` in `alemar11/homebrew-tap`.
+
+## Manual build and publish
+
+If CI publishing is unavailable, build and publish PyPI artifacts manually:
 
 ```
 uv build
-```
-
-## Uploading the distribution archives:
-
-1. Publish all files under `dist/` with uv (token via env var or flag):
-
-```
 uv publish
 ```
 
@@ -19,3 +53,20 @@ Or, using a token:
 ```
 UV_PUBLISH_TOKEN=... uv publish
 ```
+
+Then update the Homebrew formula in `alemar11/homebrew-tap` to point at the
+matching GitHub tag archive:
+
+```
+brew update-python-resources --exclude-packages pillow --package-name mangapy --version 3.0.2 Formula/mangapy.rb
+brew audit --strict --online mangapy
+brew install --build-from-source mangapy
+brew test mangapy
+```
+
+## Required GitHub/PyPI setup
+
+- Configure PyPI Trusted Publishing for `alemar11/mangapy` and
+  `.github/workflows/release.yml`.
+- Add a `HOMEBREW_TAP_TOKEN` repository secret with write access to
+  `alemar11/homebrew-tap`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mangapy"
-version = "3.0.1"
+version = "3.0.2"
 description = "Manga downloader"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -22,7 +22,7 @@ classifiers = [
 ]
 dependencies = [
   "bs4",
-  "img2pdf",
+  "img2pdf<0.4",
   "pillow",
   "pyyaml",
   "requests",

--- a/uv.lock
+++ b/uv.lock
@@ -164,6 +164,15 @@ wheels = [
 ]
 
 [[package]]
+name = "img2pdf"
+version = "0.3.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pillow" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/65/12/6ee1a77614df6decefd88f781cf95b73acf93f0cc9eb03bd5042d116b85d/img2pdf-0.3.6.tar.gz", hash = "sha256:8cd5509a60b75f4442b897bad3d593e25ebd314105f3034a8f17def396a4a0fb", size = 91006, upload-time = "2020-04-30T20:19:24.795Z" }
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -183,10 +192,11 @@ wheels = [
 
 [[package]]
 name = "mangapy"
-version = "2.1.0"
+version = "3.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "bs4" },
+    { name = "img2pdf" },
     { name = "pillow" },
     { name = "pyyaml" },
     { name = "requests" },
@@ -204,6 +214,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "bs4" },
+    { name = "img2pdf", specifier = "<0.4" },
     { name = "pillow" },
     { name = "pyyaml" },
     { name = "requests" },


### PR DESCRIPTION
## Feature

Adds Homebrew distribution for `mangapy` through `alemar11/homebrew-tap` while keeping PyPI as the source for `pipx` installs.

## Impact

- Adds a tag-driven release workflow for non-`v` version tags such as `3.0.2`.
- Publishes to PyPI with Trusted Publishing and updates the tap formula using `HOMEBREW_TAP_TOKEN`.
- Modernizes CI to supported Python versions and separates offline tests from live provider tests.
- Pins `img2pdf<0.4` so the Brew formula avoids the heavy `pikepdf`/CMake source build chain.

## Validation

- `uv lock --check`
- `uv run --locked pytest -q tests/test_cli.py tests/test_providers.py tests/test_download_manager.py tests/test_chapter_archiver.py tests/test_thread_safety.py tests/test_fanfox_search.py tests/test_fanfox_packed_js.py tests/test_sort_key.py`
- workflow YAML parse with `uv run --locked python`
- `uv build`
- `brew audit --strict --online mangapy`
- `brew install --build-from-source mangapy`
- `brew test mangapy`

## Follow-ups

- Configure PyPI Trusted Publishing for `alemar11/mangapy` before pushing the `3.0.2` tag.
